### PR TITLE
Upgrade dev workstation to 64GB RAM

### DIFF
--- a/gcp/create_dev_workstation.sh
+++ b/gcp/create_dev_workstation.sh
@@ -15,7 +15,7 @@ echo "Creating on-demand dev workstation '${VM_NAME}' with ${DISK_SIZE}GB disk..
 
 gcloud compute instances create "${VM_NAME}" \
     --zone=us-central1-a \
-    --machine-type=n2-standard-8 \
+    --machine-type=n2-standard-16 \
     --provisioning-model=STANDARD \
     --boot-disk-size="${DISK_SIZE}GB" \
     --boot-disk-type=pd-standard \
@@ -36,7 +36,7 @@ apt-get update
 apt-get install -y gh
 
 # Create 16GB swap file (half of 32GB RAM)
-fallocate -l 16G /swapfile
+fallocate -l 32G /swapfile
 chmod 600 /swapfile
 mkswap /swapfile
 swapon /swapfile


### PR DESCRIPTION
## Summary
- Bump machine type from `n2-standard-8` (32GB) to `n2-standard-16` (64GB)
- Increase swap from 16GB to 32GB to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)