### PR TITLE
Expand dataset report card national point checks to common-calibration targets

### DIFF
--- a/dataset_report_card/common.py
+++ b/dataset_report_card/common.py
@@ -14,10 +14,50 @@ USE_COLOR = True
 
 CAL_DIR = Path(__file__).resolve().parents[2] / "temp" / "policyengine-us-data" / "policyengine_us_data" / "storage" / "calibration_targets"
 
+# National target values both calibration paths target. Sourced from
+# policy_data.db (target_overview, active=1, reform_id=0, period=2024,
+# geo_level='national'). These match loss.py's HARD_CODED_TOTALS,
+# MEDICAID_*_TARGETS, ACA_*_TARGETS, RETIREMENT_CONTRIBUTION_TARGETS,
+# and get_beneficiary_paid_medicare_part_b_premiums_target(2024).
 HARD_CODED_TOTALS = {
+    # Hardcoded national dollar totals (legacy keys preserved)
     "tip_income": 38e9 * 1.4,
     "real_estate_taxes": 500e9,
     "rent": 735e9,
+    # Healthcare
+    "health_insurance_premiums_without_medicare_part_b": 385e9,
+    "other_medical_expenses": 278e9,
+    "medicare_part_b_premium": 112e9,
+    "over_the_counter_health_expenses": 72e9,
+    # Family / SPM
+    "child_support_expense": 33e9,
+    "child_support_received": 33e9,
+    "spm_unit_capped_work_childcare_expenses": 348e9,
+    "spm_unit_capped_housing_subsidy": 35e9,
+    # Income transfers
+    "tanf": 7_788_317_474.55,
+    "alimony_income": 13e9,
+    "alimony_expense": 13e9,
+    # SS splits
+    "social_security_retirement": 1_060e9,
+    "social_security_disability": 148e9,
+    "social_security_survivors": 160e9,
+    "social_security_dependents": 84e9,
+    # Retirement contributions
+    "traditional_ira_contributions": 13.771289e9,
+    "traditional_401k_contributions": 482.7e9,
+    "roth_401k_contributions": 85.2e9,
+    "roth_ira_contributions": 34.951077e9,
+    "self_employed_pension_contribution_ald": 30.130848e9,
+    # Wealth
+    "net_worth": 160e12,
+    # Medicaid / ACA national (loss.py: MEDICAID_*, ACA_*; DB: same)
+    "medicaid": 871.7e9,
+    "medicaid_enrollment_count": 72_429_055,
+    "aca_ptc_spending": 98e9,
+    "aca_ptc_enrollment_count": 19_743_689,
+    # National EITC overall (Treasury tax_expenditures.eitc; DB national row)
+    "eitc_treasury": 67.33e9,
 }
 
 FALLBACK_CBO = {
@@ -25,6 +65,7 @@ FALLBACK_CBO = {
     "social_security": 1_200e9,
     "ssi": 60e9,
     "income_tax": 4_000e9,
+    "unemployment_compensation": 34.66e9,
 }
 
 DATASET_CONFIGS = {
@@ -33,6 +74,7 @@ DATASET_CONFIGS = {
 }
 
 POINT_CHECKS = [
+    # ── EXISTING (preserved verbatim) ─────────────────────────────
     ("SNAP", "snap", "cbo:snap", 0.20),
     ("Social Security", "social_security", "cbo:social_security", 0.20),
     ("SSI", "ssi", "cbo:ssi", 0.20),
@@ -47,6 +89,135 @@ POINT_CHECKS = [
     ("Person count", "__person_count__", 335e6, 0.30),
     ("Household count", "__household_count__", 130e6, 0.30),
     ("SSN 'NONE' count", "__ssn_none__", 13e6, 0.20),
+
+    # ── EXPANDED: national targets BOTH datasets calibrate to ─────
+    # Each row below is a target present in both loss.py
+    # (enhanced_cps) and policy_data.db filtered by
+    # target_config.yaml at period=2024, geo_level='national'.
+    # JCT tax-expenditure targets (salt / charitable / medical /
+    # QBI / mortgage interest) are intentionally omitted — they
+    # would require running 5 reform Microsimulations per dataset.
+
+    # CBO national programs
+    ("Unemployment comp", "unemployment_compensation",
+        "cbo:unemployment_compensation", 0.30),
+
+    # Social Security benefit-type splits
+    ("SS retirement", "social_security_retirement",
+        HARD_CODED_TOTALS["social_security_retirement"], 0.20),
+    ("SS disability", "social_security_disability",
+        HARD_CODED_TOTALS["social_security_disability"], 0.30),
+    ("SS survivors", "social_security_survivors",
+        HARD_CODED_TOTALS["social_security_survivors"], 0.30),
+    ("SS dependents", "social_security_dependents",
+        HARD_CODED_TOTALS["social_security_dependents"], 0.30),
+
+    # Medicaid (national)
+    ("Medicaid spending", "medicaid",
+        HARD_CODED_TOTALS["medicaid"], 0.20),
+    ("Medicaid enrollment", "__medicaid_enrollment__",
+        HARD_CODED_TOTALS["medicaid_enrollment_count"], 0.20),
+
+    # ACA PTC (national)
+    ("ACA PTC spending", "aca_ptc",
+        HARD_CODED_TOTALS["aca_ptc_spending"], 0.30),
+    ("ACA PTC enrollment", "__aca_ptc_enrollment__",
+        HARD_CODED_TOTALS["aca_ptc_enrollment_count"], 0.30),
+
+    # National EITC overall (Treasury value; complements legacy
+    # "EITC" row above which uses the SOI ~$60B figure)
+    ("EITC (Treasury)", "eitc",
+        HARD_CODED_TOTALS["eitc_treasury"], 0.30),
+
+    # Healthcare totals
+    ("HIP w/o Part B", "health_insurance_premiums_without_medicare_part_b",
+        HARD_CODED_TOTALS["health_insurance_premiums_without_medicare_part_b"], 0.30),
+    ("Other med expenses", "other_medical_expenses",
+        HARD_CODED_TOTALS["other_medical_expenses"], 0.30),
+    ("Medicare Part B prem", "medicare_part_b_premium",
+        HARD_CODED_TOTALS["medicare_part_b_premium"], 0.30),
+    ("OTC health expenses", "over_the_counter_health_expenses",
+        HARD_CODED_TOTALS["over_the_counter_health_expenses"], 0.30),
+
+    # Family / SPM
+    ("Child support expense", "child_support_expense",
+        HARD_CODED_TOTALS["child_support_expense"], 0.30),
+    ("Child support recv", "child_support_received",
+        HARD_CODED_TOTALS["child_support_received"], 0.30),
+    ("Childcare expenses", "spm_unit_capped_work_childcare_expenses",
+        HARD_CODED_TOTALS["spm_unit_capped_work_childcare_expenses"], 0.30),
+    ("Housing subsidy", "spm_unit_capped_housing_subsidy",
+        HARD_CODED_TOTALS["spm_unit_capped_housing_subsidy"], 0.30),
+
+    # Income transfers
+    ("TANF", "tanf",
+        HARD_CODED_TOTALS["tanf"], 0.30),
+    ("Alimony income", "alimony_income",
+        HARD_CODED_TOTALS["alimony_income"], 0.30),
+    ("Alimony expense", "alimony_expense",
+        HARD_CODED_TOTALS["alimony_expense"], 0.30),
+
+    # Retirement contributions
+    ("Trad IRA contribs", "traditional_ira_contributions",
+        HARD_CODED_TOTALS["traditional_ira_contributions"], 0.30),
+    ("Trad 401k contribs", "traditional_401k_contributions",
+        HARD_CODED_TOTALS["traditional_401k_contributions"], 0.30),
+    ("Roth 401k contribs", "roth_401k_contributions",
+        HARD_CODED_TOTALS["roth_401k_contributions"], 0.30),
+    ("Roth IRA contribs", "roth_ira_contributions",
+        HARD_CODED_TOTALS["roth_ira_contributions"], 0.30),
+    ("SE pension ALD", "self_employed_pension_contribution_ald",
+        HARD_CODED_TOTALS["self_employed_pension_contribution_ald"], 0.30),
+
+    # Wealth
+    ("Net worth", "net_worth",
+        HARD_CODED_TOTALS["net_worth"], 0.30),
+]
+
+# Targets calibrated by only one dataset. Printed at the end of
+# step3 for transparency. Curated from loss.py and target_config.yaml
+# (relative to policy_data.db at period=2024, geo_level='national').
+ONLY_IN_LOSS_PY = [
+    "SOI AGI grid × filing status (~528 cells: AGI / count / "
+    "employment_income / business_net_profits / capital_gains_gross / "
+    "ordinary_dividends / partnership_s_corp / qualified_dividends / "
+    "taxable_interest / total_pension / total_social_security)",
+    "SOI all-AGI taxable aggregates (~14 vars: business / capital / "
+    "estate losses, exempt_interest, ira_distributions, "
+    "rent_and_royalty, mortgage_interest_deductions, taxable_pension / "
+    "SS, unemployment)",
+    "Healthcare × age-decade × 4 expense types (~36 cells)",
+    "AGI × SPM-threshold decile (count + dollars, ~20 cells)",
+    "Population by single year of age (national, 0–85)",
+    "Population by state + population under 5 by state",
+    "Negative household market income (total + count)",
+    "Infants count (national)",
+    "spm_unit_spm_threshold total",
+    "EITC × AGI × qualifying-children grid (Pub 1304 Table 2.5)",
+    "EITC by state (returns + amount per state)",
+    "JCT tax-expenditure targets — omitted from the report card; "
+    "would require 5 reform sims per dataset",
+]
+
+ONLY_IN_DB_YAML = [
+    "All district-level targets (~8,284 rows: person_count×age, "
+    "household_count×snap, AGI, real_estate_taxes, "
+    "total_self_employment_income, taxable_pension_income, eitc, "
+    "refundable_ctc, non_refundable_ctc, unemployment_compensation, "
+    "aca_ptc, tax_unit_count×aca_ptc)",
+    "State-level TANF (amount + spm_unit_count)",
+    "State-level CTC (refundable + non-refundable)",
+    "State-level income_tax (IRS SOI scalar by state)",
+    "State-level ACA marketplace counts (used_aca_ptc, "
+    "selected_marketplace_plan_benchmark_ratio)",
+    "Net capital gains national",
+    "Tax unit partnership / S-corp income national",
+    "Total self-employment income national + return count",
+    "Medical expense deduction × tax_unit_itemizes (SOI)",
+    "Qualified business income deduction national (SOI)",
+    "tax_unit_count × eitc_child_count (national, by # qualifying kids)",
+    "household_count × spm_unit_energy_subsidy_reported (LIHEAP)",
+    "Person-count × age cohort buckets (national, 18 cohorts)",
 ]
 
 RANGE_CHECKS = [
@@ -98,6 +269,14 @@ def compute_value(sim, var_key, period=2024):
         if var_key == "__ssn_none__":
             mask = sim.calculate("ssn_card_type", period=period) == "NONE"
             return float(mask.sum())
+        if var_key == "__medicaid_enrollment__":
+            return float(
+                (sim.calculate("medicaid", map_to="person", period=period) > 0).sum()
+            )
+        if var_key == "__aca_ptc_enrollment__":
+            return float(
+                (sim.calculate("aca_ptc", map_to="person", period=period) > 0).sum()
+            )
         if var_key == "__poverty_rate__":
             # Avoid expanding SPM-unit poverty status out to every person, which
             # can spike memory on large national builds.
@@ -119,7 +298,13 @@ def compute_value(sim, var_key, period=2024):
 
 def get_cbo_targets(sim, period=2024):
     targets = {}
-    for key in ["snap", "social_security", "ssi", "income_tax"]:
+    for key in [
+        "snap",
+        "social_security",
+        "ssi",
+        "income_tax",
+        "unemployment_compensation",
+    ]:
         targets[key] = resolve_cbo_target(sim, key, period)
     return targets
 

--- a/dataset_report_card/step3_report.py
+++ b/dataset_report_card/step3_report.py
@@ -7,7 +7,18 @@ import json
 import re
 import sys
 
-from common import LABEL_A, LABEL_B, VERBOSE, bold, fmt, green, hr, red
+from common import (
+    LABEL_A,
+    LABEL_B,
+    ONLY_IN_DB_YAML,
+    ONLY_IN_LOSS_PY,
+    VERBOSE,
+    bold,
+    fmt,
+    green,
+    hr,
+    red,
+)
 
 WRITE_TEXT = "--text" in sys.argv
 
@@ -181,6 +192,27 @@ def print_state_report(result_a, result_b):
     hr()
 
 
+def print_calibration_coverage_diff():
+    """Print targets calibrated by only one of the two datasets.
+
+    The point-target table above only includes targets present in
+    BOTH calibration paths. This section lists what each side
+    additionally calibrates against, so the comparison's blind
+    spots are explicit. Lists are curated in common.py.
+    """
+    print()
+    print(bold("CALIBRATION COVERAGE — TARGETS ONLY ONE SIDE CALIBRATES"))
+    hr()
+    print(bold(f"Only in {LABEL_A} (loss.py):"))
+    for item in ONLY_IN_LOSS_PY:
+        print(f"  - {item}")
+    print()
+    print(bold(f"Only in {LABEL_B} (target_config.yaml + policy_data.db):"))
+    for item in ONLY_IN_DB_YAML:
+        print(f"  - {item}")
+    hr()
+
+
 def print_summary(pt_a, pt_b, rng_a, rng_b, cons_a, cons_b, state_results):
     print()
     print(bold("SUMMARY"))
@@ -245,6 +277,7 @@ print_summary(
     cons_b,
     {"a": [aca_a, med_a], "b": [aca_b, med_b]},
 )
+print_calibration_coverage_diff()
 
 if WRITE_TEXT:
     ansi_re = re.compile(r"\033\[[0-9;]*m")


### PR DESCRIPTION
## Summary

Expands the `dataset_report_card` head-to-head comparison from 14 hand-curated point checks to 41 rows covering every national-level target that **both** `enhanced_cps_2024.h5` (calibrated via `loss.py:build_loss_matrix`) and `US.h5` (calibrated via `unified_calibration.run_calibration` reading `policy_data.db` filtered by `target_config.yaml`) actually use.

The existing 14 point checks, range checks, consistency checks, and ACA / Medicaid state checks are preserved verbatim. Only the point-check section grows.

## What changed

**`dataset_report_card/common.py`**
- `HARD_CODED_TOTALS`: 3 → 30 keys, sourced from `policy_data.db` (`target_overview` at `active=1, reform_id=0, period=2024, geo_level='national'`). Values match `loss.py`'s `HARD_CODED_TOTALS`, `MEDICAID_*_TARGETS`, `ACA_*_TARGETS`, `RETIREMENT_CONTRIBUTION_TARGETS`, and `get_beneficiary_paid_medicare_part_b_premiums_target(2024)`.
- `FALLBACK_CBO`: added `unemployment_compensation`.
- `POINT_CHECKS`: 14 → 41 rows. Original 14 preserved verbatim; 27 new rows added in 9 commented categories — CBO programs (unemployment), SS benefit-type splits (retirement / disability / survivors / dependents), Medicaid spending + enrollment, ACA PTC spending + enrollment, Treasury EITC overall, healthcare totals (HIP w/o Part B, other medical, Medicare Part B premium, OTC), family / SPM (child support expense + received, capped childcare expenses, capped housing subsidy), income transfers (TANF, alimony income / expense), retirement contributions (traditional IRA / 401k, Roth 401k / IRA, SE pension ALD), and net worth.
- `compute_value`: two new special-key handlers, `__medicaid_enrollment__` and `__aca_ptc_enrollment__`, returning the weighted person count where the variable > 0 (matching how `loss.py` defines the corresponding loss-matrix columns).
- `get_cbo_targets`: added `unemployment_compensation` to the resolved CBO key set.
- `ONLY_IN_LOSS_PY` (12 entries) and `ONLY_IN_DB_YAML` (13 entries): curated lists of national targets only one of the two calibration paths uses, surfaced in the report tail for transparency about the comparison's blind spots.

**`dataset_report_card/step3_report.py`**
- Imports `ONLY_IN_LOSS_PY` and `ONLY_IN_DB_YAML`.
- New `print_calibration_coverage_diff()` emits a `CALIBRATION COVERAGE — TARGETS ONLY ONE SIDE CALIBRATES` section after the existing summary.
- Hooked in after `print_summary()`.

`step1_dataset_a.py` and `step2b_part.py` required no changes — they iterate `POINT_CHECKS` generically and resolve `cbo:*` targets through `get_cbo_targets`.

## Deliberately excluded

JCT tax-expenditure targets (SALT / charitable / medical / QBI / mortgage interest) are not added. Computing them requires running 5 reform `Microsimulation`s per dataset; an inline comment marks the deliberate exclusion so they can be revived if the reform-sim cost is acceptable.

## Test plan

- [x] `python -c "import common; ..."` — verified all 41 `POINT_CHECKS` rows are well-formed 4-tuples and every `cbo:*` key resolves to a `FALLBACK_CBO` entry.
- [x] `py_compile` on `common.py` and `step3_report.py`.
- [x] Smoke-tested `step3_report.py` against stub `results_a.json` / `results_b.json` — new `CALIBRATION COVERAGE` section renders correctly under the existing summary.
- [ ] Run `./run.sh` end-to-end against the real `enhanced_cps_2024.h5` and a built `US.h5` to confirm new rows produce sensible numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)