### PR TITLE
Fix weighted population counts in AGI checks

### DIFF
--- a/agi_checks.py
+++ b/agi_checks.py
@@ -3,6 +3,8 @@ import pandas as pd
 from microdf import MicroDataFrame
 from policyengine_us import Microsimulation
 
+from agi_checks_helpers import summarize_young_children
+
 
 DATASET = "hf://policyengine/test/apr/states/NY.h5"
 STATE = DATASET.rsplit("/", 1)[-1].removesuffix(".h5")
@@ -131,7 +133,7 @@ print(
 
 print("\n=== Young Children in Decile 1 ===")
 person_df = sim.calculate_dataframe(
-    ["person_id", "household_id", "age", "is_child"],
+    ["person_id", "household_id", "age", "is_child", "person_weight"],
     period=YEAR,
     use_weights=False,
 )
@@ -140,16 +142,24 @@ hh_df = pd.DataFrame(
     {
         "household_id": hh_ids,
         "agi_decile": agi_deciles.values.astype(int),
+        "household_weight": household_weight.values,
     }
 )
 
 merged = person_df.merge(hh_df, on="household_id")
 decile1 = merged[merged["agi_decile"] == 1]
 young = decile1[decile1["age"] < 6]
+population_summary = summarize_young_children(decile1)
 
-print(f"Total persons in decile 1: {len(decile1)}")
-print(f"Young children (age < 6) in decile 1: {len(young)}")
-print(f"Households with young children in decile 1: {young['household_id'].nunique()}")
+print(f"Projected persons in decile 1: {population_summary['persons']:,.0f}")
+print(
+    "Projected young children (age < 6) in decile 1: "
+    f"{population_summary['young_children']:,.0f}"
+)
+print(
+    "Projected households with young children in decile 1: "
+    f"{population_summary['households_with_young_children']:,.0f}"
+)
 if len(young) > 0:
     print("\nSample young children in decile 1:")
     print(young[["person_id", "household_id", "age", "is_child"]].head(20).to_string())

--- a/agi_checks_helpers.py
+++ b/agi_checks_helpers.py
@@ -1,0 +1,11 @@
+def summarize_young_children(people):
+    young = people[people["age"] < 6]
+    young_households = young.drop_duplicates("household_id")
+
+    return {
+        "persons": float(people["person_weight"].sum()),
+        "young_children": float(young["person_weight"].sum()),
+        "households_with_young_children": float(
+            young_households["household_weight"].sum()
+        ),
+    }

--- a/tests/test_agi_checks_helpers.py
+++ b/tests/test_agi_checks_helpers.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+from agi_checks_helpers import summarize_young_children
+
+
+def test_summarize_young_children_uses_entity_weights():
+    people = pd.DataFrame(
+        {
+            "household_id": [1, 1, 2, 3, 4],
+            "age": [2, 4, 35, 5, 6],
+            "person_weight": [1.5, 1.5, 2.0, 0.75, 3.0],
+            "household_weight": [1.5, 1.5, 2.0, 0.75, 3.0],
+        }
+    )
+
+    summary = summarize_young_children(people)
+
+    assert summary == {
+        "persons": 8.75,
+        "young_children": 3.75,
+        "households_with_young_children": 2.25,
+    }
+
+
+def test_summarize_young_children_returns_zero_for_empty_subset():
+    people = pd.DataFrame(
+        {
+            "household_id": [1, 2],
+            "age": [6, 40],
+            "person_weight": [1.25, 2.5],
+            "household_weight": [1.25, 2.5],
+        }
+    )
+
+    summary = summarize_young_children(people)
+
+    assert summary == {
+        "persons": 3.75,
+        "young_children": 0.0,
+        "households_with_young_children": 0.0,
+    }


### PR DESCRIPTION
Fixes #43

## Summary

- include person and household weights in the decile-one analysis
- report projected people and young-child counts by summing person weights
- deduplicate households before summing household weights
- add focused regression tests for fractional weights, repeated household members, and an empty young-child subset

## Testing

- `uv run --with pandas --with pytest python -m pytest -q tests/test_agi_checks_helpers.py`
- `python3 -m compileall -q agi_checks.py agi_checks_helpers.py tests/test_agi_checks_helpers.py`
- `uv run --with policyengine-us --with microdf-python python agi_checks.py`